### PR TITLE
feat: add debug mode to log GraphQL requests to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A GraphQL data provider for [react-admin](https://marmelab.com/react-admin) tail
     - [Adding Authentication Headers](#adding-authentication-headers)
     - [Customize the introspection](#customize-the-introspection)
     - [Customize the Data Return](#customize-the-data-return)
+    - [Debug Mode](#debug-mode)
   - [Customizing queries](#customizing-queries)
     - [Example: extending a query to include related entities](#example-extending-a-query-to-include-related-entities)
     - [Example: write a completely custom query](#example-write-a-completely-custom-query)
@@ -374,6 +375,24 @@ React.useEffect(() => {
   buildDataProvider();
 }, []);
 ```
+
+### Debug Mode
+
+Pass `debug: true` to log every request to the browser console. Each call is rendered as a collapsible group with its `fetchType`, params, the printed GraphQL query, variables, response (or error), and duration. Requests are tagged with a sequential id (`#1`, `#2`, …) so request and response groups stay correlated even when calls interleave. Schema introspection is also logged the first time it runs.
+
+```ts
+const dataProvider = await buildHasuraProvider({
+  client: apolloClient,
+  debug: true,
+});
+```
+
+> [!WARNING]
+> Debug mode prints **everything sent to and received from Hasura**, including mutation variables (e.g. password hashes, tokens, or any other sensitive column values). Only enable it in development. Gate it behind an environment check before shipping:
+>
+> ```ts
+> debug: process.env.NODE_ENV === 'development',
+> ```
 
 ## Customizing queries
 

--- a/src/customDataProvider/index.ts
+++ b/src/customDataProvider/index.ts
@@ -30,6 +30,7 @@ import {
 } from '../buildGqlQuery/buildArgs';
 import { buildFields, BuildFields } from '../buildGqlQuery/buildFields';
 import { buildQueryFactory } from '../buildQuery';
+import { createDebugger } from '../debug';
 import type { IntrospectionResult } from '../types';
 
 const defaultOptions: Partial<Options> = {
@@ -56,8 +57,16 @@ const buildGqlQueryDefaults = {
   aggregateFieldName: (resourceName: string) => `${resourceName}_aggregate`,
 };
 
+export type CustomDataProviderOptions = Partial<Options> & {
+  /**
+   * Logs every request to the console (query, variables, response, errors,
+   * duration). Intended for development; do not enable in production.
+   */
+  debug?: boolean;
+};
+
 export type BuildCustomDataProvider = (
-  options: Partial<Options>,
+  options: CustomDataProviderOptions,
   buildGqlQueryOverrides?: {
     buildFields?: BuildFields;
     buildMetaArgs?: BuildMetaArgs;
@@ -75,6 +84,8 @@ export const buildCustomDataProvider: BuildCustomDataProvider = (
   customBuildVariables = defaultBuildVariables,
   customGetResponseParser = defaultGetResponseParser
 ) => {
+  const { debug = false, ...restOptions } = options;
+
   const buildGqlQueryOptions = {
     ...buildGqlQueryDefaults,
     ...buildGqlQueryOverrides,
@@ -96,5 +107,12 @@ export const buildCustomDataProvider: BuildCustomDataProvider = (
     customGetResponseParser
   );
 
-  return buildDataProvider(merge({}, defaultOptions, { buildQuery }, options));
+  const dbg = debug ? createDebugger() : null;
+  const finalBuildQuery = dbg ? dbg.wrapBuildQuery(buildQuery) : buildQuery;
+
+  const provider = buildDataProvider(
+    merge({}, defaultOptions, restOptions, { buildQuery: finalBuildQuery })
+  );
+
+  return dbg ? dbg.wrapDataProvider(provider) : provider;
 };

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -1,0 +1,202 @@
+import { parse } from 'graphql';
+import type { DataProvider } from 'ra-core';
+import { createDebugger } from './index';
+import type { BuildQuery } from '../buildQuery';
+import type { IntrospectionResult } from '../types';
+
+const buildIntrospection = (resourceCount = 2): IntrospectionResult =>
+  ({
+    types: [],
+    queries: [],
+    schema: {} as IntrospectionResult['schema'],
+    resources: Array.from({ length: resourceCount }, (_, i) => ({
+      type: { name: `Resource${i}` },
+    })) as IntrospectionResult['resources'],
+  }) as IntrospectionResult;
+
+const buildFakeFactory =
+  (): BuildQuery => () => (fetchType, resourceName, params) => ({
+    query: parse(`query { ${resourceName} { id } }`),
+    variables: { fetchType, resourceName, params },
+    parseResponse: ({ data }: { data: unknown }) => ({ data }) as any,
+  });
+
+const spyConsole = () => {
+  const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const groupCollapsed = jest
+    .spyOn(console, 'groupCollapsed')
+    .mockImplementation(() => {});
+  const group = jest.spyOn(console, 'group').mockImplementation(() => {});
+  const groupEnd = jest.spyOn(console, 'groupEnd').mockImplementation(() => {});
+  return { log, error, groupCollapsed, group, groupEnd };
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('createDebugger', () => {
+  it('logs introspection start once, on the first provider call', async () => {
+    const console$ = spyConsole();
+    const dbg = createDebugger();
+    const fakeProvider: DataProvider = {
+      getList: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+      getOne: jest.fn().mockResolvedValue({ data: { id: 1 } }),
+      getMany: jest.fn().mockResolvedValue({ data: [] }),
+      getManyReference: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+      create: jest.fn().mockResolvedValue({ data: { id: 1 } }),
+      update: jest.fn().mockResolvedValue({ data: { id: 1 } }),
+      updateMany: jest.fn().mockResolvedValue({ data: [] }),
+      delete: jest.fn().mockResolvedValue({ data: { id: 1 } }),
+      deleteMany: jest.fn().mockResolvedValue({ data: [] }),
+    };
+    const wrapped = dbg.wrapDataProvider(fakeProvider);
+
+    await wrapped.getList('users', {
+      pagination: { page: 1, perPage: 10 },
+    } as any);
+    await wrapped.getList('users', {
+      pagination: { page: 1, perPage: 10 },
+    } as any);
+
+    const startCalls = console$.log.mock.calls.filter((args) =>
+      String(args[0]).includes('introspection started')
+    );
+    expect(startCalls).toHaveLength(1);
+  });
+
+  it('logs introspection complete with resource count when buildQuery factory first runs', () => {
+    const console$ = spyConsole();
+    const dbg = createDebugger();
+    const wrappedFactory = dbg.wrapBuildQuery(buildFakeFactory());
+
+    wrappedFactory(buildIntrospection(3));
+    wrappedFactory(buildIntrospection(3));
+
+    const completeCalls = console$.log.mock.calls.filter((args) =>
+      String(args[0]).includes('introspection complete')
+    );
+    expect(completeCalls).toHaveLength(1);
+    expect(completeCalls[0][1]).toMatchObject({ resources: 3 });
+  });
+
+  it('correlates request id between provider wrapper and buildQuery wrapper', async () => {
+    const console$ = spyConsole();
+    const dbg = createDebugger();
+
+    const wrappedFactory = dbg.wrapBuildQuery(buildFakeFactory());
+
+    const fakeProvider: DataProvider = {
+      getList: jest.fn(async (resource, params) => {
+        wrappedFactory(buildIntrospection())(
+          'GET_LIST' as any,
+          resource,
+          params
+        );
+        return { data: [], total: 0 };
+      }),
+    } as any;
+
+    const wrapped = dbg.wrapDataProvider(fakeProvider);
+
+    await wrapped.getList('users', {} as any);
+    await wrapped.getList('posts', {} as any);
+
+    const groupTitles = console$.groupCollapsed.mock.calls.map(
+      (args) => args[0] as string
+    );
+
+    const requestStarts = groupTitles.filter((t) =>
+      /#\d+ getList \w+$/.test(t)
+    );
+    const completions = groupTitles.filter((t) =>
+      /#\d+ getList \w+ done \(\d+ms\)/.test(t)
+    );
+    expect(requestStarts).toEqual([
+      expect.stringContaining('#1 getList users'),
+      expect.stringContaining('#2 getList posts'),
+    ]);
+    expect(completions).toEqual([
+      expect.stringMatching(/#1 getList users done/),
+      expect.stringMatching(/#2 getList posts done/),
+    ]);
+  });
+
+  it('logs errors via console.error and rethrows', async () => {
+    const console$ = spyConsole();
+    const dbg = createDebugger();
+
+    const boom = new Error('network failure');
+    const fakeProvider: DataProvider = {
+      getList: jest.fn().mockRejectedValue(boom),
+    } as any;
+
+    const wrapped = dbg.wrapDataProvider(fakeProvider);
+
+    await expect(wrapped.getList('users', {} as any)).rejects.toBe(boom);
+
+    expect(
+      console$.error.mock.calls.some((args) =>
+        String(args[0]).includes('introspection failed')
+      )
+    ).toBe(true);
+    expect(console$.error.mock.calls.some((args) => args[0] === boom)).toBe(
+      true
+    );
+  });
+
+  it('does not flag introspection failure when introspection already completed', async () => {
+    const console$ = spyConsole();
+    const dbg = createDebugger();
+    const wrappedFactory = dbg.wrapBuildQuery(buildFakeFactory());
+    wrappedFactory(buildIntrospection());
+
+    const boom = new Error('post-introspection failure');
+    const fakeProvider: DataProvider = {
+      getList: jest.fn().mockRejectedValue(boom),
+    } as any;
+    const wrapped = dbg.wrapDataProvider(fakeProvider);
+
+    await expect(wrapped.getList('users', {} as any)).rejects.toBe(boom);
+
+    expect(
+      console$.error.mock.calls.some((args) =>
+        String(args[0]).includes('introspection failed')
+      )
+    ).toBe(false);
+  });
+
+  it('logs printed GraphQL query and variables on request start', () => {
+    const console$ = spyConsole();
+    const dbg = createDebugger();
+
+    const wrappedFactory = dbg.wrapBuildQuery(buildFakeFactory());
+
+    const fakeProvider: DataProvider = {
+      getList: jest.fn(async (resource, params) => {
+        wrappedFactory(buildIntrospection())(
+          'GET_LIST' as any,
+          resource,
+          params
+        );
+        return { data: [], total: 0 };
+      }),
+    } as any;
+
+    const wrapped = dbg.wrapDataProvider(fakeProvider);
+    return wrapped.getList('users', { foo: 'bar' } as any).then(() => {
+      const queryLogs = console$.log.mock.calls.filter(
+        (args) => args[0] === 'query'
+      );
+      expect(queryLogs).toHaveLength(1);
+      expect(String(queryLogs[0][1])).toContain('users');
+
+      const varLogs = console$.log.mock.calls.filter(
+        (args) => args[0] === 'variables'
+      );
+      expect(varLogs).toHaveLength(1);
+      expect(varLogs[0][1]).toMatchObject({ resourceName: 'users' });
+    });
+  });
+});

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -22,14 +22,15 @@ const buildFakeFactory =
   });
 
 const spyConsole = () => {
-  const log = jest.spyOn(console, 'log').mockImplementation(() => {});
-  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
-  const groupCollapsed = jest
-    .spyOn(console, 'groupCollapsed')
-    .mockImplementation(() => {});
-  const group = jest.spyOn(console, 'group').mockImplementation(() => {});
-  const groupEnd = jest.spyOn(console, 'groupEnd').mockImplementation(() => {});
-  return { log, error, groupCollapsed, group, groupEnd };
+  jest.spyOn(console, 'group').mockImplementation(() => {});
+  jest.spyOn(console, 'groupEnd').mockImplementation(() => {});
+  return {
+    log: jest.spyOn(console, 'log').mockImplementation(() => {}),
+    error: jest.spyOn(console, 'error').mockImplementation(() => {}),
+    groupCollapsed: jest
+      .spyOn(console, 'groupCollapsed')
+      .mockImplementation(() => {}),
+  };
 };
 
 afterEach(() => {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,155 @@
+import { print } from 'graphql';
+import type { DataProvider } from 'ra-core';
+import type { BuildQuery } from '../buildQuery';
+import type { IntrospectionResult } from '../types';
+
+type RequestCtx = {
+  id: number;
+  fetchType: string;
+  resource: string;
+  start: number;
+};
+
+const PROVIDER_METHODS = [
+  'getList',
+  'getOne',
+  'getMany',
+  'getManyReference',
+  'create',
+  'update',
+  'updateMany',
+  'delete',
+  'deleteMany',
+] as const;
+
+const TAG = '[ra-data-hasura]';
+
+export type Debugger = {
+  wrapBuildQuery: (factory: BuildQuery) => BuildQuery;
+  wrapDataProvider: (provider: DataProvider) => DataProvider;
+};
+
+export const createDebugger = (): Debugger => {
+  let counter = 0;
+  let introspectionStartedAt = 0;
+  let introspectionLogged = false;
+  let introspectionRequested = false;
+  const pending: RequestCtx[] = [];
+
+  const safe = (fn: () => void) => {
+    try {
+      fn();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`${TAG} debug logging failed`, err);
+    }
+  };
+
+  const wrapBuildQuery: Debugger['wrapBuildQuery'] = (originalFactory) => {
+    return (introspectionResults: IntrospectionResult) => {
+      if (!introspectionLogged) {
+        introspectionLogged = true;
+        const durationMs = introspectionStartedAt
+          ? Date.now() - introspectionStartedAt
+          : 0;
+        safe(() => {
+          // eslint-disable-next-line no-console
+          console.log(`${TAG} introspection complete`, {
+            durationMs,
+            resources: introspectionResults.resources.length,
+          });
+        });
+      }
+      const realBuildQuery = originalFactory(introspectionResults);
+      return (fetchType, resource, params) => {
+        const result = realBuildQuery(fetchType, resource, params);
+        const ctx = pending.shift();
+        const id = ctx ? ctx.id : 0;
+        const method = ctx ? ctx.fetchType : String(fetchType);
+        safe(() => {
+          // eslint-disable-next-line no-console
+          console.groupCollapsed(`${TAG} #${id} ${method} ${resource}`);
+          // eslint-disable-next-line no-console
+          console.log('fetchType', fetchType);
+          // eslint-disable-next-line no-console
+          console.log('params', params);
+          let queryString: string;
+          try {
+            queryString = print(result.query);
+          } catch {
+            queryString = String(result.query);
+          }
+          // eslint-disable-next-line no-console
+          console.log('query', queryString);
+          // eslint-disable-next-line no-console
+          console.log('variables', result.variables);
+          // eslint-disable-next-line no-console
+          console.groupEnd();
+        });
+        return result;
+      };
+    };
+  };
+
+  const wrapDataProvider: Debugger['wrapDataProvider'] = (provider) => {
+    const wrapped: Record<string, unknown> = { ...provider };
+    for (const method of PROVIDER_METHODS) {
+      const original = (provider as unknown as Record<string, unknown>)[method];
+      if (typeof original !== 'function') continue;
+      wrapped[method] = async (resource: string, params: unknown) => {
+        if (!introspectionRequested) {
+          introspectionRequested = true;
+          introspectionStartedAt = Date.now();
+          safe(() => {
+            // eslint-disable-next-line no-console
+            console.log(`${TAG} introspection started`);
+          });
+        }
+        const ctx: RequestCtx = {
+          id: ++counter,
+          fetchType: method,
+          resource,
+          start: Date.now(),
+        };
+        pending.push(ctx);
+        try {
+          const result = await (
+            original as (...a: unknown[]) => Promise<unknown>
+          ).call(provider, resource, params);
+          const durationMs = Date.now() - ctx.start;
+          safe(() => {
+            // eslint-disable-next-line no-console
+            console.groupCollapsed(
+              `${TAG} #${ctx.id} ${ctx.fetchType} ${ctx.resource} done (${durationMs}ms)`
+            );
+            // eslint-disable-next-line no-console
+            console.log('response', result);
+            // eslint-disable-next-line no-console
+            console.groupEnd();
+          });
+          return result;
+        } catch (error) {
+          const durationMs = Date.now() - ctx.start;
+          safe(() => {
+            if (!introspectionLogged) {
+              // eslint-disable-next-line no-console
+              console.error(`${TAG} introspection failed`, error);
+            }
+            // eslint-disable-next-line no-console
+            console.group(
+              `${TAG} #${ctx.id} ${ctx.fetchType} ${ctx.resource} failed (${durationMs}ms)`
+            );
+            // eslint-disable-next-line no-console
+            console.error(error);
+            // eslint-disable-next-line no-console
+            console.groupEnd();
+          });
+          throw error;
+        }
+      };
+    }
+    return wrapped as unknown as DataProvider;
+  };
+
+  return { wrapBuildQuery, wrapDataProvider };
+};

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -5,7 +5,7 @@ import type { IntrospectionResult } from '../types';
 
 type RequestCtx = {
   id: number;
-  fetchType: string;
+  method: string;
   resource: string;
   start: number;
 };
@@ -33,14 +33,12 @@ export const createDebugger = (): Debugger => {
   let counter = 0;
   let introspectionStartedAt = 0;
   let introspectionLogged = false;
-  let introspectionRequested = false;
   const pending: RequestCtx[] = [];
 
   const safe = (fn: () => void) => {
     try {
       fn();
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.error(`${TAG} debug logging failed`, err);
     }
   };
@@ -53,7 +51,6 @@ export const createDebugger = (): Debugger => {
           ? Date.now() - introspectionStartedAt
           : 0;
         safe(() => {
-          // eslint-disable-next-line no-console
           console.log(`${TAG} introspection complete`, {
             durationMs,
             resources: introspectionResults.resources.length,
@@ -64,14 +61,11 @@ export const createDebugger = (): Debugger => {
       return (fetchType, resource, params) => {
         const result = realBuildQuery(fetchType, resource, params);
         const ctx = pending.shift();
-        const id = ctx ? ctx.id : 0;
-        const method = ctx ? ctx.fetchType : String(fetchType);
+        const id = ctx?.id ?? 0;
+        const method = ctx?.method ?? String(fetchType);
         safe(() => {
-          // eslint-disable-next-line no-console
           console.groupCollapsed(`${TAG} #${id} ${method} ${resource}`);
-          // eslint-disable-next-line no-console
           console.log('fetchType', fetchType);
-          // eslint-disable-next-line no-console
           console.log('params', params);
           let queryString: string;
           try {
@@ -79,11 +73,8 @@ export const createDebugger = (): Debugger => {
           } catch {
             queryString = String(result.query);
           }
-          // eslint-disable-next-line no-console
           console.log('query', queryString);
-          // eslint-disable-next-line no-console
           console.log('variables', result.variables);
-          // eslint-disable-next-line no-console
           console.groupEnd();
         });
         return result;
@@ -97,17 +88,15 @@ export const createDebugger = (): Debugger => {
       const original = (provider as unknown as Record<string, unknown>)[method];
       if (typeof original !== 'function') continue;
       wrapped[method] = async (resource: string, params: unknown) => {
-        if (!introspectionRequested) {
-          introspectionRequested = true;
+        if (!introspectionStartedAt) {
           introspectionStartedAt = Date.now();
           safe(() => {
-            // eslint-disable-next-line no-console
             console.log(`${TAG} introspection started`);
           });
         }
         const ctx: RequestCtx = {
           id: ++counter,
-          fetchType: method,
+          method,
           resource,
           start: Date.now(),
         };
@@ -118,13 +107,10 @@ export const createDebugger = (): Debugger => {
           ).call(provider, resource, params);
           const durationMs = Date.now() - ctx.start;
           safe(() => {
-            // eslint-disable-next-line no-console
             console.groupCollapsed(
-              `${TAG} #${ctx.id} ${ctx.fetchType} ${ctx.resource} done (${durationMs}ms)`
+              `${TAG} #${ctx.id} ${ctx.method} ${ctx.resource} done (${durationMs}ms)`
             );
-            // eslint-disable-next-line no-console
             console.log('response', result);
-            // eslint-disable-next-line no-console
             console.groupEnd();
           });
           return result;
@@ -132,16 +118,12 @@ export const createDebugger = (): Debugger => {
           const durationMs = Date.now() - ctx.start;
           safe(() => {
             if (!introspectionLogged) {
-              // eslint-disable-next-line no-console
               console.error(`${TAG} introspection failed`, error);
             }
-            // eslint-disable-next-line no-console
             console.group(
-              `${TAG} #${ctx.id} ${ctx.fetchType} ${ctx.resource} failed (${durationMs}ms)`
+              `${TAG} #${ctx.id} ${ctx.method} ${ctx.resource} failed (${durationMs}ms)`
             );
-            // eslint-disable-next-line no-console
             console.error(error);
-            // eslint-disable-next-line no-console
             console.groupEnd();
           });
           throw error;


### PR DESCRIPTION
## Summary

- Adds a `debug: true` option to `buildCustomDataProvider` / `buildHasuraProvider` that logs every GraphQL request to the browser console
- Each call is rendered as a collapsible group with `fetchType`, params, printed query, variables, response (or error), and duration, tagged with a sequential id (`#1`, `#2`, …) so interleaved calls stay correlated
- Schema introspection is also logged (start, complete with resource count, or failure)
- Moves `lodash` from `dependencies` to `devDependencies` (it was already only used at build time)

## Test plan

- [ ] `npm test` passes (new `src/debug/debug.test.ts` covers introspection logging, request correlation, error handling, and query/variable output)
- [ ] Manually verify console groups appear in browser devtools with `debug: true`
- [ ] Confirm no console output when `debug` is omitted or `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)