### PR TITLE
docs: fix package name in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ Now use this local package in your React app for testing:
 
 ```sh
 cd my-react-app
-npm link ra-data-hasura
+npm link @aginix/ra-data-hasura
 ```
 
 Build the library by running `npm run build` — output is generated in the `dist` folder.


### PR DESCRIPTION
Update the `npm link` command in the Contributing section to use `@aginix/ra-data-hasura` instead of the old `ra-data-hasura` package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)